### PR TITLE
Remove print statement

### DIFF
--- a/flip/transformers/domain_randomization/draw.py
+++ b/flip/transformers/domain_randomization/draw.py
@@ -24,8 +24,6 @@ class Draw(Transformer):
                 y=obj.y,
             )
 
-        print("Image created")
-
         element.created_image = Element(image=image, name='created_final')
 
         return element


### PR DESCRIPTION
When generating many images it is useful to use a progress bar like the one from `tqdm`. However, having this print statement slows down the processing while polluting the screen like it's shown here:

![image](https://user-images.githubusercontent.com/42240853/214007407-079043f1-df20-4001-bae5-5ff39658815b.png)
